### PR TITLE
add Utils.hs module so eval can be called from cabal repl

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,59 +1,7 @@
 module Main where
 
-import Cardano.Binary qualified as CBOR
-import Data.Aeson (KeyValue ((.=)), object)
-import Data.Aeson.Encode.Pretty (encodePretty)
-import Data.Bifunctor (
-  first,
- )
-import Data.ByteString.Base16 qualified as Base16
-import Data.ByteString.Lazy qualified as LBS
-import Data.Text (
-  Text,
-  pack,
- )
-import Data.Text.Encoding qualified as Text
-import Plutarch (
-  Config (Config),
-  TracingMode (DoTracing),
-  compile,
- )
-import Plutarch.Evaluate (
-  evalScript,
- )
-import "liqwid-plutarch-extra" Plutarch.Extra.Script (
-  applyArguments,
- )
-import Plutarch.Prelude
-import Plutarch.Script (Script, serialiseScript)
-import PlutusLedgerApi.V2 (
-  Data,
-  ExBudget,
- )
+import Utils
 import Sample
-
-encodeSerialiseCBOR :: Script -> Text
-encodeSerialiseCBOR = Text.decodeUtf8 . Base16.encode . CBOR.serialize' . serialiseScript
-
-evalT :: ClosedTerm a -> Either Text (Script, ExBudget, [Text])
-evalT x = evalWithArgsT x []
-
-evalWithArgsT :: ClosedTerm a -> [Data] -> Either Text (Script, ExBudget, [Text])
-evalWithArgsT x args = do
-  cmp <- compile (Config DoTracing) x
-  let (escr, budg, trc) = evalScript $ applyArguments cmp args
-  scr <- first (pack . show) escr
-  pure (scr, budg, trc)
-
-writePlutusScript :: String -> FilePath -> ClosedTerm a -> IO ()
-writePlutusScript title filepath term = do
-  case evalT term of
-    Left e -> putStrLn (show e)
-    Right (script, _, _) -> do
-      let scriptType = "PlutusScriptV2" :: String
-          plutusJson = object ["type" .= scriptType, "description" .= title, "cborHex" .= encodeSerialiseCBOR script]
-          content = encodePretty plutusJson
-      LBS.writeFile filepath content
 
 main :: IO ()
 main = do

--- a/plutarch-csa.cabal
+++ b/plutarch-csa.cabal
@@ -109,7 +109,9 @@ common common
 
 library
     import:           common
-    exposed-modules:  Sample
+    exposed-modules:  
+      , Sample
+      , Utils
     -- other-modules:
     -- other-extensions:
     build-depends:

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,0 +1,55 @@
+module Utils (evalT, evalWithArgsT, writePlutusScript) where
+
+import Cardano.Binary qualified as CBOR
+import Data.Aeson (KeyValue ((.=)), object)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Bifunctor (
+  first,
+ )
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Lazy qualified as LBS
+import Data.Text (
+  Text,
+  pack,
+ )
+import Data.Text.Encoding qualified as Text
+import Plutarch (
+  Config (Config),
+  TracingMode (DoTracing),
+  compile,
+ )
+import Plutarch.Evaluate (
+  evalScript,
+ )
+import Plutarch.Prelude
+import Plutarch.Script (Script, serialiseScript)
+import PlutusLedgerApi.V2 (
+  Data,
+  ExBudget,
+ )
+import "liqwid-plutarch-extra" Plutarch.Extra.Script (
+  applyArguments,
+ )
+
+encodeSerialiseCBOR :: Script -> Text
+encodeSerialiseCBOR = Text.decodeUtf8 . Base16.encode . CBOR.serialize' . serialiseScript
+
+evalT :: ClosedTerm a -> Either Text (Script, ExBudget, [Text])
+evalT x = evalWithArgsT x []
+
+evalWithArgsT :: ClosedTerm a -> [Data] -> Either Text (Script, ExBudget, [Text])
+evalWithArgsT x args = do
+  cmp <- compile (Config DoTracing) x
+  let (escr, budg, trc) = evalScript $ applyArguments cmp args
+  scr <- first (pack . show) escr
+  pure (scr, budg, trc)
+
+writePlutusScript :: String -> FilePath -> ClosedTerm a -> IO ()
+writePlutusScript title filepath term = do
+  case evalT term of
+    Left e -> putStrLn (show e)
+    Right (script, _, _) -> do
+      let scriptType = "PlutusScriptV2" :: String
+          plutusJson = object ["type" .= scriptType, "description" .= title, "cborHex" .= encodeSerialiseCBOR script]
+          content = encodePretty plutusJson
+      LBS.writeFile filepath content


### PR DESCRIPTION
Move evaluation functions out of Main.hs and into src/Utils.hs, and expose the Utils module so developers can evaluate validator UPLC from the cabal repl in an interactive session, like:

```
$ cabal repl
ghci> import Utils
ghci> evalT gift
Right (Script {unScript = Program {_progAnn = (), _progVer = Version () 1 0 0, _progTerm = LamAbs () (DeBruijn {dbnIndex = 0}) (LamAbs () (DeBruijn {dbnIndex = 0}) (LamAbs () (DeBruijn {dbnIndex = 0}) (Constant () (Some (ValueOf DefaultUniUnit ())))))}},ExBudget {exBudgetCPU = ExCPU 23100, exBudgetMemory = ExMemory 200},[])
```